### PR TITLE
Fixed the dub.json examples

### DIFF
--- a/packages/glfw3/index.html
+++ b/packages/glfw3/index.html
@@ -662,12 +662,8 @@
 <span class="s2">&quot;subConfigurations&quot;</span><span class="err">:</span> <span class="p">{</span>
     <span class="nt">&quot;derelict-glfw3&quot;</span><span class="p">:</span> <span class="s2">&quot;derelict-glfw3-static&quot;</span>
 <span class="p">}</span><span class="err">,</span>
-<span class="s2">&quot;libs-windows&quot;</span><span class="err">:</span> <span class="p">{</span>
-    <span class="nt">&quot;glfw3dll&quot;</span>
-<span class="p">}</span><span class="err">,</span>
-<span class="s2">&quot;libs-posix&quot;</span><span class="err">:</span> <span class="p">{</span>
-    <span class="nt">&quot;glfw3&quot;</span>
-<span class="p">}</span>
+<span class="s2">&quot;libs-windows&quot;</span><span class="err">:</span> <span class="p">[</span><span class="s2">&quot;glfw3dll&quot;</span><span class="p">]</span><span class="err">,</span>
+<span class="s2">&quot;libs-posix&quot;</span><span class="err">:</span> <span class="p">[</span><span class="s2">&quot;glfw3&quot;</span><span class="p">]</span>
 </pre></div>
 
 
@@ -685,12 +681,8 @@ libs <span class="s2">&quot;glfw3&quot;</span> <span class="nv">platform</span><
     <span class="nt">&quot;derelict-glfw3&quot;</span><span class="p">:</span> <span class="s2">&quot;~&gt;4.0.0-beta&quot;</span>
 <span class="p">}</span><span class="err">,</span>
 <span class="s2">&quot;versions&quot;</span><span class="err">:</span> <span class="p">[</span><span class="s2">&quot;DerelictGLFW3_Static&quot;</span><span class="p">]</span><span class="err">,</span>
-<span class="s2">&quot;libs-windows&quot;</span><span class="err">:</span> <span class="p">{</span>
-    <span class="nt">&quot;glfw3dll&quot;</span>
-<span class="p">}</span><span class="err">,</span>
-<span class="s2">&quot;libs-posix&quot;</span><span class="err">:</span> <span class="p">{</span>
-    <span class="nt">&quot;glfw3&quot;</span>
-<span class="p">}</span>
+<span class="s2">&quot;libs-windows&quot;</span><span class="err">:</span> <span class="p">[</span><span class="s2">&quot;glfw3dll&quot;</span><span class="p">]</span><span class="err">,</span>
+<span class="s2">&quot;libs-posix&quot;</span><span class="err">:</span> <span class="p">[</span><span class="s2">&quot;glfw3&quot;</span><span class="p">]</span>
 </pre></div>
 
 

--- a/packages/sdl2/index.html
+++ b/packages/sdl2/index.html
@@ -695,9 +695,7 @@
 <span class="s2">&quot;subConfigurations&quot;</span><span class="err">:</span> <span class="p">{</span>
     <span class="nt">&quot;derelict-sdl2&quot;</span><span class="p">:</span> <span class="s2">&quot;derelict-sdl2-static&quot;</span>
 <span class="p">}</span><span class="err">,</span>
-<span class="s2">&quot;libs&quot;</span><span class="err">:</span> <span class="p">{</span>
-    <span class="nt">&quot;sdl2&quot;</span>
-<span class="p">}</span><span class="err">,</span>
+<span class="s2">&quot;libs&quot;</span><span class="err">:</span> <span class="p">[</span><span class="s2">&quot;sdl2&quot;</span><span class="p">]</span><span class="err">,</span>
 </pre></div>
 
 
@@ -714,9 +712,7 @@ libs <span class="s2">&quot;sdl2&quot;</span>
     <span class="nt">&quot;derelict-sdl2&quot;</span><span class="p">:</span> <span class="s2">&quot;~&gt;3.0.0-beta&quot;</span>
 <span class="p">}</span><span class="err">,</span>
 <span class="s2">&quot;versions&quot;</span><span class="err">:</span> <span class="p">[</span><span class="s2">&quot;DerelictSDL2_Static&quot;</span><span class="p">]</span><span class="err">,</span>
-<span class="s2">&quot;libs&quot;</span><span class="err">:</span> <span class="p">{</span>
-    <span class="nt">&quot;sdl2&quot;</span>
-<span class="p">}</span>
+<span class="s2">&quot;libs&quot;</span><span class="err">:</span> <span class="p">[</span><span class="s2">&quot;sdl2&quot;</span><span class="p">]</span><span class="err">,</span>
 </pre></div>
 
 


### PR DESCRIPTION
Using the examples as-is threw errors when trying to build with dub.  The "libs" should be an array of strings.